### PR TITLE
Add class filter params to FroData requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 0.9.5
+
+* Add support for `Class` criteria
+
+## 0.9.4
+
+* Not documented upstream
+
 ## 0.9.3
 
 * Fix broken stack traces in response errors

--- a/lib/frodata/query.rb
+++ b/lib/frodata/query.rb
@@ -68,6 +68,11 @@ module FrOData
       self
     end
 
+    def filter_class(term)
+      criteria_set[:Class] << term
+      self
+    end
+
     # Adds a filter criteria to the query with 'and' logical operator.
     # @param criteria
     #def and(criteria)
@@ -190,6 +195,7 @@ module FrOData
         orderby:      [],
         skip:         0,
         top:          0,
+        Class:        [],
         inline_count: false
       }
     end
@@ -198,6 +204,7 @@ module FrOData
       [
         filter_criteria,
         search_criteria,
+        class_criteria,
         list_criteria(:orderby),
         list_criteria(:expand),
         list_criteria(:select),
@@ -207,6 +214,12 @@ module FrOData
       ].compact.reduce(&:merge)
     end
 
+    def class_criteria
+      return nil if criteria_set[:Class].empty?
+      filters = criteria_set[:Class].collect(&:to_s)
+      "Class=#{filters.join(' AND ')}"
+    end
+    
     def filter_criteria
       return nil if criteria_set[:filter].empty?
       filters = criteria_set[:filter].collect(&:to_s)

--- a/lib/frodata/version.rb
+++ b/lib/frodata/version.rb
@@ -1,3 +1,3 @@
 module FrOData
-  VERSION = '0.9.4'
+  VERSION = '0.9.5'
 end


### PR DESCRIPTION
Metrolistapi has only one property resource class `Property` but when querying  for listings, one can only query for a specific property class, e.g `Residential`

These changes add a method that appends the class query param to FroData requests then loops through all the property classes to and combines the results to be displayed on rets browser. 

The way this was done is not so clean though.